### PR TITLE
Don't include garbage entry in cgo import table

### DIFF
--- a/src/cmd/cgo/out.go
+++ b/src/cmd/cgo/out.go
@@ -389,6 +389,10 @@ func dynimport(obj string) {
 			fatalf("cannot load imported libraries from XCOFF file %s: %v", obj, err)
 		}
 		for _, l := range lib {
+			// XXX: WHY
+			if l == "../" {
+				continue
+			}
 			fmt.Fprintf(stdout, "//go:cgo_import_dynamic _ _ %q\n", l)
 		}
 		return


### PR DESCRIPTION
../ isn't a real library, silly.

With gcc 10 and MAXGOPROCS=1, this lets Go build on i 7.4 with the
bootstrap tarball.

Not a real fix - why does this garbage entry appear from the XCOFF
parser?